### PR TITLE
Remove central server option

### DIFF
--- a/ASR_Offline_FailoverTransfertASG.ps1
+++ b/ASR_Offline_FailoverTransfertASG.ps1
@@ -3,7 +3,6 @@ param(
   [Parameter(Mandatory = $False)][string]$RgPrimaire, # resource group where VM are going to be updated
   [Parameter(Mandatory = $true)][string]$RgDestination, # resource group where VM are replicated
   [Parameter(Mandatory = $False)][string]$CustomFilePath,
-  [Parameter(Mandatory = $False)][switch]$CentralServerOnly
 )
 
 function WriteLog
@@ -31,19 +30,7 @@ function WriteLog
 $ErrorActionPreference = "Stop"
 Set-AzContext -SubscriptionId $sid | Out-Null
 $extraArgs = @{}
-$VMQuery = "resources
-              | where type == 'microsoft.compute/virtualmachines' and resourceGroup == '$($RgPrimaire)'
-              | where tags['test-function'] == 'central'
-              | project name"
-$Centralname = (Search-AzGraph -Query $VMQuery).name
 $FileFilter = "*json"
-if($CentralServerOnly)
-{
-  $FileFilter = "$($Centralname).json"
-}
-else {
-  $extraArgs["Exclude"] = "$($Centralname).json"
-}
 
 if($CustomFilePath)
 {


### PR DESCRIPTION
## Summary
- sanitize scripts for public use
- remove the `CentralServerOnly` parameter and related logic

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686906e733a08331ad7f97175e44e1ee